### PR TITLE
fix: Missing use statement.

### DIFF
--- a/src/Listener/SaveTrelloIdToDatabase.php
+++ b/src/Listener/SaveTrelloIdToDatabase.php
@@ -17,6 +17,7 @@ use Flarum\Discussion\Event\Saving;
 use Flarum\Http\UrlGenerator;
 use Flarum\Settings\SettingsRepositoryInterface;
 use Illuminate\Support\Arr;
+use Symfony\Contracts\Translation\TranslatorInterface;
 use Trello\Client;
 use Trello\Model\Card;
 


### PR DESCRIPTION
Fixes the error where the use statement is missing.