### PR TITLE
feat: Only primary tags should be sent to Trello by default

### DIFF
--- a/js/src/admin/components/ExtensionSettingsPage.tsx
+++ b/js/src/admin/components/ExtensionSettingsPage.tsx
@@ -145,8 +145,8 @@ export default class TrelloSettingsPage extends ExtensionPage {
           </div>
           <hr />
           <div class="Form-group">
+            <h3>{app.translator.trans('blomstra-trello.admin.settings.label.boards')}</h3>
             <label>{app.translator.trans('blomstra-trello.admin.settings.available_boards_label')}</label>
-
             {this.states.allBoards === null ? (
               <LoadingIndicator />
             ) : this.states.allBoards ? (

--- a/js/src/admin/components/ExtensionSettingsPage.tsx
+++ b/js/src/admin/components/ExtensionSettingsPage.tsx
@@ -219,6 +219,16 @@ export default class TrelloSettingsPage extends ExtensionPage {
               }, {}),
             })
           )}
+          <hr />
+          <div class="Form-group">
+            <h3>{app.translator.trans('blomstra-trello.admin.settings.label.optional')}</h3>
+            {this.buildSettingComponent({
+              type: 'boolean',
+              setting: 'blomstra-trello.include_secondary_tags_as_trello_labels',
+              label: app.translator.trans('blomstra-trello.admin.settings.include_secondary_tags_label'),
+              help: app.translator.trans('blomstra-trello.admin.settings.include_secondary_tags_help'),
+            })}
+          </div>
           <div class="Form-group">{this.submitButton()}</div>
         </div>
       </div>,

--- a/locale/en.yml
+++ b/locale/en.yml
@@ -24,7 +24,7 @@ blomstra-trello:
       no_selected_boards_label: No selected boards
       selected_boards_label: Selected boards
       include_secondary_tags_label: Include secondary tags
-      include_secondary_tags_help: When this option is disabled, this extension will ignore secondary tags (they will not be included in the Trello payload). When this option is enabled, all tags for the discussion will be sent to Trello.
+      include_secondary_tags_help: When disabled, only primary discussion tags will be sent to Trello. When enabled, all tags will be sent to Trello.
 
   forum:
     badges:

--- a/locale/en.yml
+++ b/locale/en.yml
@@ -9,6 +9,7 @@ blomstra-trello:
       label:
         general: General
         boards: Boards Settings
+        optional: Optional Settings
       api_key_help: Enter the API key from {link} in order for this extension to connect with Trello.
       api_key_label: API Key
       api_token_help: Enter the API token in order for this extension to connect with Trello. Visit {link} and click <code>Generate a Token</code>
@@ -22,6 +23,8 @@ blomstra-trello:
       no_available_boards_label: No available boards
       no_selected_boards_label: No selected boards
       selected_boards_label: Selected boards
+      include_secondary_tags_label: Include secondary tags
+      include_secondary_tags_help: When this option is disabled, this extension will ignore secondary tags (they will not be included in the Trello payload). When this option is enabled, all tags for the discussion will be sent to Trello.
 
   forum:
     badges:

--- a/src/Listener/SaveTrelloIdToDatabase.php
+++ b/src/Listener/SaveTrelloIdToDatabase.php
@@ -113,7 +113,11 @@ class SaveTrelloIdToDatabase
             if ($board) {
                 $labels = collect($board->getLabels());
 
-                $discussion->tags->each(function ($tag) use ($labels, $board, $card) {
+                $includeSecondaryTags = $this->settings->get('blomstra-trello.include_secondary_tags_as_trello_labels', false);
+
+                $discussion->tags->filter(function ($tag) use ($includeSecondaryTags) {
+                    return $includeSecondaryTags ?: !is_null($tag->position);
+                })->each(function ($tag) use ($labels, $board, $card) {
                     $label = $labels->filter(function ($label) use ($tag) {
                         return $label->name == $tag->name;
                     })->first();

--- a/src/Listener/SaveTrelloIdToDatabase.php
+++ b/src/Listener/SaveTrelloIdToDatabase.php
@@ -113,7 +113,7 @@ class SaveTrelloIdToDatabase
             if ($board) {
                 $labels = collect($board->getLabels());
 
-                $includeSecondaryTags = $this->settings->get('blomstra-trello.include_secondary_tags_as_trello_labels', false);
+                $includeSecondaryTags = (bool) $this->settings->get('blomstra-trello.include_secondary_tags_as_trello_labels', false);
 
                 $discussion->tags->filter(function ($tag) use ($includeSecondaryTags) {
                     return $includeSecondaryTags ?: !is_null($tag->position);


### PR DESCRIPTION
See: [Orion: Trello: Only primary tags should be sent to Trello](https://trello.com/c/ydf1AG5i)