### PR TITLE
fix: Last lane not always working

### DIFF
--- a/js/src/forum/components/SendToTrelloModal.tsx
+++ b/js/src/forum/components/SendToTrelloModal.tsx
@@ -197,6 +197,8 @@ export default class SendToTrelloModal extends Modal {
           app.current.stream.update();
         }
 
+        app.forum.data.attributes.trelloDefaultBoardId = selected.board.short_link;
+        app.forum.data.attributes.trelloLastUsedLaneId = selected.lane;
         m.redraw();
 
         this.loading = false;

--- a/src/Listener/SaveTrelloIdToDatabase.php
+++ b/src/Listener/SaveTrelloIdToDatabase.php
@@ -62,6 +62,7 @@ class SaveTrelloIdToDatabase
                 $discussion->trello_card_id = $card->shortLink;
 
                 $this->rememberLastUsedLaneId($attributes['trello']['lane']);
+                $this->rememberLastUsedBoardId($attributes['trello']['board']['short_link']);
 
                 $this->attachLabelsToCardBasedOnForumTags($discussion, $card, $attributes['trello']['board']['short_link']);
             }
@@ -102,6 +103,15 @@ class SaveTrelloIdToDatabase
 
         if (strcmp($currentSetting, $lane) != 0) {
             $this->settings->set('blomstra-trello.last_used_lane_id', $lane);
+        }
+    }
+
+    private function rememberLastUsedBoardId(string $shortLink): void
+    {
+        $currentSetting = $this->settings->get('blomstra-trello.default_board_id');
+
+        if (strcmp($currentSetting, $shortLink) != 0) {
+            $this->settings->set('blomstra-trello.default_board_id', $shortLink);
         }
     }
 

--- a/src/Listener/SaveTrelloIdToDatabase.php
+++ b/src/Listener/SaveTrelloIdToDatabase.php
@@ -101,7 +101,7 @@ class SaveTrelloIdToDatabase
     {
         $currentSetting = $this->settings->get('blomstra-trello.last_used_lane_id');
 
-        if (strcmp($currentSetting, $lane) != 0) {
+        if (strcmp($currentSetting, $lane) !== 0) {
             $this->settings->set('blomstra-trello.last_used_lane_id', $lane);
         }
     }
@@ -110,7 +110,7 @@ class SaveTrelloIdToDatabase
     {
         $currentSetting = $this->settings->get('blomstra-trello.default_board_id');
 
-        if (strcmp($currentSetting, $shortLink) != 0) {
+        if (strcmp($currentSetting, $shortLink) !== 0) {
             $this->settings->set('blomstra-trello.default_board_id', $shortLink);
         }
     }


### PR DESCRIPTION
See: [Orion: Trello: Last lane state not remembered after change](https://trello.com/c/kcYdYNIu)