### PR TITLE
Fix ICU syntax used in translations

### DIFF
--- a/locale/en.yml
+++ b/locale/en.yml
@@ -57,7 +57,7 @@ blomstra-trello:
         board: Select a Trello board
         lane: Select a Trello lane
         member: Select a Trello member
-        member_selected: "{count, plural, one {# member}, other {# members}} selected"
+        member_selected: "{count, plural, one {# member} other {# members}} selected"
       no_available_board_lanes: No available board lanes
       no_available_board_members: No available board members
       no_available_boards_label: No available boards


### PR DESCRIPTION
I'm not sure if old syntax works in Flarum, but there should be no comma between variants, and Weblate or https://format-message.github.io/icu-message-format-for-translators/editor.html report this as error.